### PR TITLE
Ignore case when finding an adapter

### DIFF
--- a/src/Enchilada/Infrastructure/EnchiladaFileProviderResolver.cs
+++ b/src/Enchilada/Infrastructure/EnchiladaFileProviderResolver.cs
@@ -23,7 +23,7 @@
             var providerUri = new Uri( uri );
 
             var matchingProvider = enchiladaConfiguration.Adapters
-                                                         .FirstOrDefault( x => x.AdapterName == providerUri.Host );
+                                                         .FirstOrDefault( x => string.Equals(x.AdapterName, providerUri.Host, StringComparison.OrdinalIgnoreCase) );
 
             return (IFileProvider) Activator.CreateInstance( matchingProvider.FileProvider, matchingProvider, providerUri.PathAndQuery );
         }


### PR DESCRIPTION
If an Adapter is configured with different casing. It fails loading adapter.